### PR TITLE
Redis storage & jwt

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ _**Note** : This a modified version version of [EddyTravels/smooch](https://gith
 
 ## Additional Feature
 
-- Redis support as a centralized storage to store JWT token for supporting autoscaling environment.
+- Token expiration & its checking.
+- Renew token functionality whenever token is expired.
+- Redis support as a centralized storage to store JWT token for supporting autoscaling environment. Use redigo as redis library.
 
 ## Tips
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ func main() {
         KeyID:        os.Getenv("SMOOCH_KEY_ID"),
         Secret:       os.Getenv("SMOOCH_SECRET"),
         VerifySecret: os.Getenv("SMOOCH_VERIFY_SECRET"),
+        RedisPool:    redisPool,
     })
 
     if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,10 @@
-module github.com/EddyTravels/smooch
+module github.com/kitabisa/smooch
 
 require (
+	github.com/EddyTravels/smooch v0.1.0 // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/gomodule/redigo v2.0.0+incompatible
 	github.com/stretchr/testify v1.3.0
 )
+
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/kitabisa/smooch
 
 require (
-	github.com/EddyTravels/smooch v0.1.0 // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gomodule/redigo v2.0.0+incompatible
 	github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/EddyTravels/smooch v0.1.0 h1:dbG4EK3otBtqL3JyGhJ6PVLMh42DI/M5pIFiRP4ATAo=
-github.com/EddyTravels/smooch v0.1.0/go.mod h1:KIl3bCuRqlVyuIUVX5MPeQYexUbMcp+tU7UOZIeD7zc=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,12 @@
+github.com/EddyTravels/smooch v0.1.0 h1:dbG4EK3otBtqL3JyGhJ6PVLMh42DI/M5pIFiRP4ATAo=
+github.com/EddyTravels/smooch v0.1.0/go.mod h1:KIl3bCuRqlVyuIUVX5MPeQYexUbMcp+tU7UOZIeD7zc=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/gomodule/redigo v2.0.0+incompatible h1:K/R+8tc58AaqLkqG2Ol3Qk+DR/TlNuhuh457pBFPtt0=
+github.com/gomodule/redigo v2.0.0+incompatible/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
+github.com/kitabisa/smooch v0.1.0 h1:dS+ouObVdoNFVZWMIqULMr/VbQoYhsBuSUdmp0VjbcM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/jwt.go
+++ b/jwt.go
@@ -1,12 +1,18 @@
 package smooch
 
 import (
+	"time"
+
 	jwt "github.com/dgrijalva/jwt-go"
 )
+
+// JWTExpiration defines how many seconds jwt token is valid
+const JWTExpiration = 3600
 
 func GenerateJWT(scope string, keyID string, secret string) (string, error) {
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
 		"scope": scope,
+		"exp":   JWTExpiration,
 	})
 	token.Header = map[string]interface{}{
 		"alg": "HS256",
@@ -19,7 +25,17 @@ func GenerateJWT(scope string, keyID string, secret string) (string, error) {
 
 // getJWTExpiration will get jwt expiration time
 func getJWTExpiration(jwtToken string, secret string) (int64, error) {
-	// TODO ....
+	claims := jwt.MapClaims{}
+
+	_, err := jwt.ParseWithClaims(jwtToken, &claims, func(t *jwt.Token) (interface{}, error) {
+		return []byte(secret), nil
+	})
+	if err != nil {
+		return -1, err
+	}
+
+	expiredIn := claims["exp"].(int64) - time.Now().Unix()
+	return expiredIn, nil
 }
 
 // isJWTExpired will check whether Smooch JWT is expired or not.

--- a/jwt.go
+++ b/jwt.go
@@ -17,6 +17,11 @@ func GenerateJWT(scope string, keyID string, secret string) (string, error) {
 	return token.SignedString([]byte(secret))
 }
 
+// getJWTExpiration will get jwt expiration time
+func getJWTExpiration(jwtToken string, secret string) (int64, error) {
+	// TODO ....
+}
+
 // isJWTExpired will check whether Smooch JWT is expired or not.
 func isJWTExpired(jwtToken string, secret string) (bool, error) {
 	_, err := jwt.ParseWithClaims(jwtToken, jwt.MapClaims{}, func(t *jwt.Token) (interface{}, error) {

--- a/jwt.go
+++ b/jwt.go
@@ -16,3 +16,23 @@ func GenerateJWT(scope string, keyID string, secret string) (string, error) {
 
 	return token.SignedString([]byte(secret))
 }
+
+// isJWTExpired will check whether Smooch JWT is expired or not.
+func isJWTExpired(jwtToken string, secret string) (bool, error) {
+	_, err := jwt.ParseWithClaims(jwtToken, jwt.MapClaims{}, func(t *jwt.Token) (interface{}, error) {
+		return []byte(secret), nil
+	})
+
+	if err == nil {
+		return false, nil
+	}
+
+	switch err.(type) {
+	case *jwt.ValidationError:
+		vErr := err.(*jwt.ValidationError)
+		if vErr.Errors == jwt.ValidationErrorExpired {
+			return true, nil
+		}
+	}
+	return false, err
+}

--- a/storage/redis.go
+++ b/storage/redis.go
@@ -1,0 +1,40 @@
+package storage
+
+import (
+	"github.com/gomodule/redigo/redis"
+)
+
+// RedisStorage defines struct property for redis storage
+type RedisStorage struct {
+	pool   *redis.Pool
+	jwtKey string
+}
+
+// NewRedisStorage initializes new instance of redis storage
+func NewRedisStorage(p *redis.Pool) *RedisStorage {
+	return &RedisStorage{
+		pool:   p,
+		jwtKey: "smooch-jwt-token",
+	}
+}
+
+// SaveTokenToRedis will save jwt token to redis
+func (rs *RedisStorage) SaveTokenToRedis(token string, ttl int64) error {
+	conn := rs.pool.Get()
+	defer conn.Close()
+
+	_, err := conn.Do("SETEX", rs.jwtKey, ttl, token)
+	return err
+}
+
+// GetTokenFromRedis will retrieve jwt token from redis
+func (rs *RedisStorage) GetTokenFromRedis() (string, error) {
+	conn := rs.pool.Get()
+	defer conn.Close()
+
+	val, err := redis.String(conn.Do("GET", rs.jwtKey))
+	if err != nil {
+		return "", err
+	}
+	return val, nil
+}


### PR DESCRIPTION
- Token expiration & its checking.
- Renew token functionality whenever token is expired.
- Redis support as a centralized storage to store JWT token for supporting autoscaling environment. Use redigo as redis library.