### PR TITLE
remove verify secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ func main() {
         AppID:        os.Getenv("SMOOCH_APP_ID"),
         KeyID:        os.Getenv("SMOOCH_KEY_ID"),
         Secret:       os.Getenv("SMOOCH_SECRET"),
-        VerifySecret: os.Getenv("SMOOCH_VERIFY_SECRET"),
         RedisPool:    redisPool,
     })
 

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,7 @@ github.com/gomodule/redigo v2.0.0+incompatible/go.mod h1:B4C85qUVwatsJoIUNIfCRsp
 github.com/kitabisa/smooch v0.1.0 h1:dS+ouObVdoNFVZWMIqULMr/VbQoYhsBuSUdmp0VjbcM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/smooch_test.go
+++ b/smooch_test.go
@@ -221,8 +221,7 @@ func TestSendOKResponse(t *testing.T) {
 	}
 
 	sc, err := New(Options{
-		VerifySecret: "very-secure-test-secret",
-		HttpClient:   NewTestClient(fn),
+		HttpClient: NewTestClient(fn),
 	})
 	assert.NoError(t, err)
 
@@ -288,8 +287,7 @@ func TestSendErrorResponse(t *testing.T) {
 	}
 
 	sc, err := New(Options{
-		VerifySecret: "very-secure-test-secret",
-		HttpClient:   NewTestClient(fn),
+		HttpClient: NewTestClient(fn),
 	})
 	assert.NoError(t, err)
 
@@ -310,9 +308,7 @@ func TestSendErrorResponse(t *testing.T) {
 }
 
 func TestHandlerOK(t *testing.T) {
-	sc, err := New(Options{
-		VerifySecret: "very-secure-test-secret",
-	})
+	sc, err := New(Options{})
 	assert.NoError(t, err)
 
 	handlerInvokeCounter := 0
@@ -342,43 +338,6 @@ func TestHandlerOK(t *testing.T) {
 	assert.Equal(t, 2, handlerInvokeCounter)
 }
 
-func TestVerifyRequest(t *testing.T) {
-	sc, err := New(Options{
-		VerifySecret: "very-secure-test-secret",
-	})
-	r := &http.Request{}
-	assert.NoError(t, err)
-	assert.False(t, sc.VerifyRequest(r))
-
-	r = &http.Request{
-		Header: http.Header{},
-	}
-	r.Header.Set("X-Api-Key", "very-secure-test-secret")
-	assert.NoError(t, err)
-	assert.True(t, sc.VerifyRequest(r))
-
-	sc, err = New(Options{
-		VerifySecret: "very-secure-test-secret",
-	})
-	assert.NoError(t, err)
-
-	headers := http.Header{}
-	headers.Set("X-Api-Key", "very-secure-test-secret-wrong")
-	r = &http.Request{
-		Header: headers,
-	}
-	assert.NoError(t, err)
-	assert.False(t, sc.VerifyRequest(r))
-
-	headers = http.Header{}
-	headers.Set("X-Api-Key", "very-secure-test-secret")
-	r = &http.Request{
-		Header: headers,
-	}
-	assert.NoError(t, err)
-	assert.True(t, sc.VerifyRequest(r))
-}
-
 func TestGetAppUser(t *testing.T) {
 	fn := func(req *http.Request) *http.Response {
 
@@ -393,8 +352,7 @@ func TestGetAppUser(t *testing.T) {
 	}
 
 	sc, err := New(Options{
-		VerifySecret: "very-secure-test-secret",
-		HttpClient:   NewTestClient(fn),
+		HttpClient: NewTestClient(fn),
 	})
 	assert.NoError(t, err)
 
@@ -448,8 +406,7 @@ func TestUploadAttachment(t *testing.T) {
 	}
 
 	sc, err := New(Options{
-		VerifySecret: "very-secure-test-secret",
-		HttpClient:   NewTestClient(fn),
+		HttpClient: NewTestClient(fn),
 	})
 	assert.NoError(t, err)
 
@@ -483,8 +440,7 @@ func TestDeleteAttachment(t *testing.T) {
 	}
 
 	sc, err := New(Options{
-		VerifySecret: "very-secure-test-secret",
-		HttpClient:   NewTestClient(fn),
+		HttpClient: NewTestClient(fn),
 	})
 	assert.NoError(t, err)
 


### PR DESCRIPTION
**Why remove verify secret?**
Verify secret is not provided by smooch. It's just a token to secure request between client & messaging service, by checking equality between `verifySecret key` and header `X-Api-Key`. 

In this case, we don't need it because we only access santet service from internal and santet isn't exposed to public.